### PR TITLE
Fix after-callback cleanup

### DIFF
--- a/Raman_Integration/gui.py
+++ b/Raman_Integration/gui.py
@@ -782,7 +782,8 @@ class RamanApp(ctk.CTk):
         fig_manager = plt._pylab_helpers.Gcf.get_all_fig_managers()
         for manager in fig_manager:
             if hasattr(manager, 'canvas') and hasattr(manager.canvas, '_tkcanvas'):
-                for after_id in manager.canvas._tkcanvas.tk.call('after', 'info'):
+                ids = manager.canvas._tkcanvas.tk.call('after', 'info')
+                for after_id in str(ids).split():
                     try:
                         manager.canvas._tkcanvas.after_cancel(after_id)
                     except Exception:


### PR DESCRIPTION
## Summary
- properly split `tk.call('after', 'info')` output so each ID is cancelled

## Testing
- `python3 -m py_compile Raman_Integration/gui.py Raman_Integration/main.py Raman_Integration/math_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ed286ef08329a0c0dce32a3aae07