### PR TITLE
Add peak raw intensities and separate ratio worksheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ The output workbook includes:
 
 - **Integration**: Areas for each defined range.
 - **Peaks**: Baseline-subtracted and raw intensities for each peak.
-- **Ratios**: Custom ratio calculations.
-- **Spectral Math**: Additional user-defined formulas.
+- **Ratios**: Custom ratio calculations for integrated areas.
+- **Peak Ratios**: Ratio calculations for peak intensities.
+- **Spectral Math**: Additional user-defined formulas for integrated areas.
+- **Peak Spectral Math**: User formulas applied to peak intensities.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- include raw peak intensity results in analysis helpers
- export peak ratios and spectral math to dedicated worksheets
- document new workbook sheets

## Testing
- `python3 -m py_compile Raman_Integration/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68431be29a788329952f39fd1d5424b3